### PR TITLE
Removes unnecessary dotenv dependency and loading call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 import os
-from dotenv import load_dotenv
 import subprocess
 
 # Load environment variables from .env file
-load_dotenv()
 
 GUARDRAILS_TOKEN = os.getenv("GUARDRAILS_TOKEN")
 if not GUARDRAILS_TOKEN:


### PR DESCRIPTION
Eliminates the import and invocation of the environment variable loader since environment variables are expected to be set externally. This simplifies setup and reduces dependency overhead without affecting functionality.