### PR TITLE
Moves guardrails setup call above imports and cleans requirements

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 from fastapi import FastAPI, HTTPException
+from setup import setup_guardrails
+
+setup_guardrails()
+
 from guardrail.pii_detection_guardrails_ai import pii_detection_guardrails_ai
 from guardrail.pii_redaction_presidio import process_input_guardrail
 from guardrail.nsfw_filtering_local_eval import nsfw_filtering
 from guardrail.drug_mention_guardrails_ai import drug_mention
 from guardrail.web_sanitization_guardrails_ai import web_sanitization
-from setup import setup_guardrails
-
-setup_guardrails()
 
 # Create FastAPI app instance
 app = FastAPI(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,5 @@ presidio-anonymizer
 fastapi
 uvicorn
 pydantic
-torch
-transformers
 guardrails-ai
 guardrails-ai[api]


### PR DESCRIPTION
Reorders the initialization to call the guardrails setup before importing related modules, ensuring proper configuration is in place prior to use.

Removes unnecessary dependencies from the requirements, streamlining the environment and reducing potential package overhead.c