### PR TITLE
updated templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The application follows a modular architecture with separate modules for differe
   - **`nsfw_filtering_local_eval.py`**: NSFW content filtering using local Unitary toxic classification model
   - **`drug_mention_guardrails_ai.py`**: Drug mention detection using Guardrails AI
   - **`web_sanitization_guardrails_ai.py`**: Web content sanitization using Guardrails AI
-- **`entities.py`**: Pydantic models for request/response validation
+- **`entities.py`**: Pydantic models for gateway payloads and typed guardrail responses (`InputGuardrailRequest`, `OutputGuardrailRequest`, `ValidateGuardrailResponse`, `MutateGuardrailResponse`, etc.)
 
 ## Currently Exposed Endpoints
 
@@ -23,18 +23,20 @@ The Guardrail Server currently exposes two main endpoints for validation:
 - **POST `/pii-redaction`**
 - Validates and optionally transforms incoming OpenAI chat completion requests before they are processed. Uses Presidio to detect and redact Personally Identifiable Information (PII) from messages.
 
-#### What does guardrail server respond with?
-- `null` - Guardrails passed, no transformation needed for input.
-- `ChatCompletionCreateParams` - Content was transformed, returns the modified request with PII redacted.
-- `HTTP 400/500` - Guardrails failed with error details for input.
+#### What does the guardrail server respond with?
+
+Endpoints return **HTTP 2xx** with a **JSON body** that matches the [TrueFoundry AI Gateway custom guardrail contract](https://docs.truefoundry.com/gateway/custom-guardrails) (see also `ValidateGuardrailResponse` / `MutateGuardrailResponse` in `entities.py`):
+
+- **Mutate (`/pii-redaction`)** — `verdict`, `transformed`, and `result` (full OpenAI-shaped `requestBody` when `transformed` is `true`). Use **2xx** for both allow and deny; do not use **HTTP 400** for policy blocks.
+- **Non-2xx** — reserved for real failures (misconfiguration, dependency errors, crashes).
 
 ### NSFW Filtering Endpoint (Local Model)
 - **POST `/nsfw-filtering`**
 - Validates and optionally transforms outgoing OpenAI chat completion responses to filter out NSFW content. Uses the Unitary toxic classification model to detect toxic, sexually explicit, and obscene content.
 
-#### What does guardrail server respond with?
-- `null` - Guardrails passed, no transformation needed for output.
-- `HTTP 400/500` - Guardrails failed with error details for output.
+#### What does the guardrail server respond with?
+
+**HTTP 2xx** with **`verdict`** (and optional **`message`**) for allow/deny. Policy deny is expressed with **`verdict: false`** on **2xx**, not with **HTTP 400**. See `ValidateGuardrailResponse` in `entities.py` and the [custom guardrails](https://docs.truefoundry.com/gateway/custom-guardrails) doc.
 
 
 
@@ -64,6 +66,25 @@ If you are using `guardrails ai` guards in your guardrails, you will also need g
 - `responseBody`: (ChatCompletion) The model's output to be checked by the guardrail server.
 - `config`: (dict) Configuration options for the guardrail server.
 - `context`: (RequestContext) Contextual information such as user and metadata.
+
+### ValidateGuardrailResponse
+
+Used by **validate**-operation guardrails (input or output). FastAPI serializes this model to JSON for the gateway.
+
+**Attributes:**
+
+- `verdict`: (`bool`) `true` = allow, `false` = deny (preferred explicit signal on **2xx**).
+- `message`: (`Optional[str]`) Optional human-readable text for logs or UI; not used by the gateway for allow/deny decisions.
+
+### MutateGuardrailResponse
+
+Used by **mutate**-operation guardrails (e.g. PII redaction). FastAPI serializes this model to JSON for the gateway.
+
+**Attributes:**
+
+- `verdict`: (`bool`) Allow/deny when present; mutate handlers in this template typically return `true` when the call completed successfully.
+- `transformed`: (`bool`) `true` = replace request or response body with `result`; `false` = keep the original body.
+- `result`: (`dict[str, Any]`) Full OpenAI-shaped **`requestBody`** or **`responseBody`** to apply when `transformed` is `true`.
 
 ### RequestContext
 
@@ -538,7 +559,7 @@ The modular architecture makes it easy to customize the guardrail logic:
 
 - **PII Redaction**: Modify `guardrail/pii_redaction_presidio.py` to customize PII detection and redaction rules
 - **NSFW Filtering (Local)**: Modify `guardrail/nsfw_filtering_local_eval.py` to customize content filtering thresholds and rules
-- **Request/Response Models**: Modify `entities.py` to add new fields or validation rules
+- **Request / response models**: Modify `entities.py` to add fields or new Pydantic types; keep guardrail return types aligned with `ValidateGuardrailResponse` / `MutateGuardrailResponse` (or extend them) so the JSON matches the gateway contract.
 
 Replace the example guardrail logic in the respective files with your own implementation. The NSFW filtering uses the Unitary toxic classification model with configurable thresholds for toxicity, sexual content, and obscenity detection.
 
@@ -616,65 +637,45 @@ Create a new file in the `guardrail/` directory following this pattern:
 
 **For Input Validation** (e.g., `guardrail/your_validator_guardrails_ai.py`):
 ```python
-from typing import Optional
-from fastapi import HTTPException
 from guardrails import Guard
 from guardrails.hub import YourValidator  # Import your validator
 
-from entities import InputGuardrailRequest
+from entities import InputGuardrailRequest, ValidateGuardrailResponse
 
 # Setup the Guard with the validator
 guard = Guard().use(YourValidator, on_fail="exception")
 
-def your_validator_function(request: InputGuardrailRequest) -> Optional[dict]:
-    """
-    Validate input using Guardrails AI validator.
-    
-    Args:
-        request: Input guardrail request containing messages to validate
-        
-    Returns:
-        None if validation passes, raises HTTPException if validation fails
-    """
+def your_validator_function(request: InputGuardrailRequest) -> ValidateGuardrailResponse:
+    """Validate input using Guardrails AI; return 2xx JSON for both allow and deny."""
     try:
         messages = request.requestBody.get("messages", [])
         for message in messages:
             if isinstance(message, dict) and message.get("content"):
                 guard.validate(message["content"])
-        return None
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        return ValidateGuardrailResponse(verdict=False, message=str(e))
+    return ValidateGuardrailResponse(verdict=True)
 ```
 
 **For Output Validation** (e.g., `guardrail/your_output_validator_guardrails_ai.py`):
 ```python
-from typing import Optional
-from fastapi import HTTPException
 from guardrails import Guard
 from guardrails.hub import YourOutputValidator  # Import your validator
 
-from entities import OutputGuardrailRequest
+from entities import OutputGuardrailRequest, ValidateGuardrailResponse
 
 # Setup the Guard with the validator
 guard = Guard().use(YourOutputValidator, on_fail="exception")
 
-def your_output_validator_function(request: OutputGuardrailRequest) -> Optional[dict]:
-    """
-    Validate output using Guardrails AI validator.
-    
-    Args:
-        request: Output guardrail request containing response to validate
-        
-    Returns:
-        None if validation passes, raises HTTPException if validation fails
-    """
+def your_output_validator_function(request: OutputGuardrailRequest) -> ValidateGuardrailResponse:
+    """Validate output using Guardrails AI; return 2xx JSON for both allow and deny."""
     try:
         for choice in request.responseBody.get("choices", []):
             if "content" in choice.get("message", {}):
                 guard.validate(choice["message"]["content"])
-        return None
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        return ValidateGuardrailResponse(verdict=False, message=str(e))
+    return ValidateGuardrailResponse(verdict=True)
 ```
 
 #### Step 3: Add the Route
@@ -691,10 +692,10 @@ app.add_api_route("/your-endpoint", endpoint=your_validator_function, methods=["
 
 ### Best Practices
 
-1. **Error Handling**: Always wrap validator calls in try-catch blocks
-2. **HTTP Status Codes**: Use appropriate status codes (400 for validation failures, 500 for server errors)
-3. **Logging**: Consider adding logging for debugging and monitoring
-4. **Testing**: Test your validators with various inputs including edge cases
+1. **Error handling**: Wrap validator calls in try/except; return `ValidateGuardrailResponse(verdict=False, message=...)` on policy failure instead of raising **HTTP 400** for content denial (so `enforce_but_ignore_on_error` and similar strategies behave correctly).
+2. **HTTP status**: Use **2xx** for completed guardrail runs (allow or deny via `verdict`). Reserve **4xx/5xx** for genuine server or dependency failures.
+3. **Logging**: Add logging for debugging and monitoring where helpful.
+4. **Testing**: Test validators with varied inputs and edge cases.
 
 ## Adding New Endpoints
 

--- a/entities.py
+++ b/entities.py
@@ -1,5 +1,21 @@
-from typing import Optional
+from typing import Any, Optional
+
 from pydantic import BaseModel
+
+
+class ValidateGuardrailResponse(BaseModel):
+    """Response body for validate-operation guardrails (AI Gateway JSON contract)."""
+
+    verdict: bool
+    message: Optional[str] = None
+
+
+class MutateGuardrailResponse(BaseModel):
+    """Response body for mutate-operation guardrails (AI Gateway JSON contract)."""
+
+    verdict: bool
+    transformed: bool
+    result: dict[str, Any]
 
 
 class RequestContext(BaseModel):

--- a/guardrail/drug_mention_guardrails_ai.py
+++ b/guardrail/drug_mention_guardrails_ai.py
@@ -1,5 +1,3 @@
-from typing import Optional
-from fastapi import HTTPException
 from guardrails import Guard
 from guardrails.hub import MentionsDrugs
 
@@ -8,10 +6,12 @@ from entities import OutputGuardrailRequest
 # Setup the Guard with the validator
 guard = Guard().use(MentionsDrugs, on_fail="exception")
 
-def drug_mention(request: OutputGuardrailRequest) -> Optional[dict]:
+
+def drug_mention(request: OutputGuardrailRequest) -> dict:
     try:
         for choice in request.responseBody.get("choices", []):
             if "content" in choice.get("message", {}):
                 guard.validate(choice["message"]["content"])
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        return {"verdict": False, "message": str(e)}
+    return {"verdict": True}

--- a/guardrail/drug_mention_guardrails_ai.py
+++ b/guardrail/drug_mention_guardrails_ai.py
@@ -1,17 +1,17 @@
 from guardrails import Guard
 from guardrails.hub import MentionsDrugs
 
-from entities import OutputGuardrailRequest
+from entities import OutputGuardrailRequest, ValidateGuardrailResponse
 
 # Setup the Guard with the validator
 guard = Guard().use(MentionsDrugs, on_fail="exception")
 
 
-def drug_mention(request: OutputGuardrailRequest) -> dict:
+def drug_mention(request: OutputGuardrailRequest) -> ValidateGuardrailResponse:
     try:
         for choice in request.responseBody.get("choices", []):
             if "content" in choice.get("message", {}):
                 guard.validate(choice["message"]["content"])
     except Exception as e:
-        return {"verdict": False, "message": str(e)}
-    return {"verdict": True}
+        return ValidateGuardrailResponse(verdict=False, message=str(e))
+    return ValidateGuardrailResponse(verdict=True)

--- a/guardrail/nsfw_filtering_local_eval.py
+++ b/guardrail/nsfw_filtering_local_eval.py
@@ -1,10 +1,10 @@
-from entities import OutputGuardrailRequest
+from entities import OutputGuardrailRequest, ValidateGuardrailResponse
 from transformers import pipeline
 
 classifier = pipeline("text-classification", model="unitary/unbiased-toxic-roberta")
 
 
-def nsfw_filtering(request: OutputGuardrailRequest) -> dict:
+def nsfw_filtering(request: OutputGuardrailRequest) -> ValidateGuardrailResponse:
     for choice in request.responseBody.get("choices", []):
         if "content" in choice.get("message", {}):
             classification_results = classifier(choice["message"]["content"])
@@ -14,8 +14,8 @@ def nsfw_filtering(request: OutputGuardrailRequest) -> dict:
                     or (result["label"] == "sexual_explicit" and result["score"] > 0.2)
                     or (result["label"] == "obscene" and result["score"] > 0.2)
                 ):
-                    return {
-                        "verdict": False,
-                        "message": "This message is not allowed as it is NSFW",
-                    }
-    return {"verdict": True}
+                    return ValidateGuardrailResponse(
+                        verdict=False,
+                        message="This message is not allowed as it is NSFW",
+                    )
+    return ValidateGuardrailResponse(verdict=True)

--- a/guardrail/nsfw_filtering_local_eval.py
+++ b/guardrail/nsfw_filtering_local_eval.py
@@ -1,21 +1,21 @@
-from typing import Optional
-
-from fastapi import HTTPException
 from entities import OutputGuardrailRequest
 from transformers import pipeline
 
 classifier = pipeline("text-classification", model="unitary/unbiased-toxic-roberta")
 
-def nsfw_filtering(request: OutputGuardrailRequest) -> Optional[dict]:
-    transformed_body = request.responseBody.copy()  # Use dict copy method
-    for choice in transformed_body.get("choices", []):
+
+def nsfw_filtering(request: OutputGuardrailRequest) -> dict:
+    for choice in request.responseBody.get("choices", []):
         if "content" in choice.get("message", {}):
             classification_results = classifier(choice["message"]["content"])
             for result in classification_results:
                 if (
-                    (result['label'] == 'toxicity' and result['score'] > 0.2) or
-                    (result['label'] == 'sexual_explicit' and result['score'] > 0.2) or
-                    (result['label'] == 'obscene' and result['score'] > 0.2)
+                    (result["label"] == "toxicity" and result["score"] > 0.2)
+                    or (result["label"] == "sexual_explicit" and result["score"] > 0.2)
+                    or (result["label"] == "obscene" and result["score"] > 0.2)
                 ):
-                    raise HTTPException(status_code=400, detail=f"This message is not allowed as it is NSFW")
-
+                    return {
+                        "verdict": False,
+                        "message": "This message is not allowed as it is NSFW",
+                    }
+    return {"verdict": True}

--- a/guardrail/pii_detection_guardrails_ai.py
+++ b/guardrail/pii_detection_guardrails_ai.py
@@ -1,18 +1,18 @@
 from guardrails import Guard
 from guardrails.hub import DetectPII
 
-from entities import InputGuardrailRequest
+from entities import InputGuardrailRequest, ValidateGuardrailResponse
 
 # Setup the Guard with the validator
 guard = Guard().use(DetectPII, on_fail="exception")
 
 
-def pii_detection_guardrails_ai(request: InputGuardrailRequest) -> dict:
+def pii_detection_guardrails_ai(request: InputGuardrailRequest) -> ValidateGuardrailResponse:
     try:
         messages = request.requestBody.get("messages", [])
         for message in messages:
             if isinstance(message, dict) and message.get("content"):
                 guard.validate(message["content"])
     except Exception as e:
-        return {"verdict": False, "message": str(e)}
-    return {"verdict": True}
+        return ValidateGuardrailResponse(verdict=False, message=str(e))
+    return ValidateGuardrailResponse(verdict=True)

--- a/guardrail/pii_detection_guardrails_ai.py
+++ b/guardrail/pii_detection_guardrails_ai.py
@@ -1,21 +1,18 @@
-from typing import Optional
-from fastapi import HTTPException
 from guardrails import Guard
-from guardrails.hub import (
-    DetectPII
-)
+from guardrails.hub import DetectPII
 
 from entities import InputGuardrailRequest
 
 # Setup the Guard with the validator
 guard = Guard().use(DetectPII, on_fail="exception")
 
-def pii_detection_guardrails_ai(request: InputGuardrailRequest) -> Optional[dict]:
+
+def pii_detection_guardrails_ai(request: InputGuardrailRequest) -> dict:
     try:
         messages = request.requestBody.get("messages", [])
         for message in messages:
             if isinstance(message, dict) and message.get("content"):
                 guard.validate(message["content"])
-        return None
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        return {"verdict": False, "message": str(e)}
+    return {"verdict": True}

--- a/guardrail/pii_redaction_presidio.py
+++ b/guardrail/pii_redaction_presidio.py
@@ -2,19 +2,19 @@ import copy
 import logging
 from typing import Any
 
-from entities import InputGuardrailRequest
+from entities import InputGuardrailRequest, MutateGuardrailResponse
 from presidio_entities import DEFAULT_LANGUAGE, DEFAULT_RECOGNIZERS, parse_recognizers, get_analyzer, anonymizer
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
 
-def _response(verdict: bool, transformed: bool, result: dict[str, Any]) -> dict[str, Any]:
+def _response(verdict: bool, transformed: bool, result: dict[str, Any]) -> MutateGuardrailResponse:
     """AI Gateway mutate contract: 2xx JSON with verdict, transformed, and full requestBody in result."""
-    return {"verdict": verdict, "transformed": transformed, "result": result}
+    return MutateGuardrailResponse(verdict=verdict, transformed=transformed, result=result)
 
 
-def process_input_guardrail(request: InputGuardrailRequest) -> dict[str, Any]:
+def process_input_guardrail(request: InputGuardrailRequest) -> MutateGuardrailResponse:
     body = copy.deepcopy(request.requestBody)
 
     if not request.config.get("transform_input", False):

--- a/guardrail/pii_redaction_presidio.py
+++ b/guardrail/pii_redaction_presidio.py
@@ -1,5 +1,6 @@
+import copy
 import logging
-from typing import Optional
+from typing import Any
 
 from entities import InputGuardrailRequest
 from presidio_entities import DEFAULT_LANGUAGE, DEFAULT_RECOGNIZERS, parse_recognizers, get_analyzer, anonymizer
@@ -8,62 +9,53 @@ from presidio_entities import DEFAULT_LANGUAGE, DEFAULT_RECOGNIZERS, parse_recog
 logger = logging.getLogger(__name__)
 
 
+def _response(verdict: bool, transformed: bool, result: dict[str, Any]) -> dict[str, Any]:
+    """AI Gateway mutate contract: 2xx JSON with verdict, transformed, and full requestBody in result."""
+    return {"verdict": verdict, "transformed": transformed, "result": result}
 
-def process_input_guardrail(request: InputGuardrailRequest) -> Optional[dict]:    # Check if transformation is enabled
+
+def process_input_guardrail(request: InputGuardrailRequest) -> dict[str, Any]:
+    body = copy.deepcopy(request.requestBody)
+
     if not request.config.get("transform_input", False):
         logger.debug("Transform input disabled, skipping PII redaction")
-        return None
-    
-    # Get recognizer configuration
-    recognizer_config = request.config.get("recognizers",DEFAULT_RECOGNIZERS)
-    
-    # Get language configuration
+        return _response(True, False, body)
+
+    recognizer_config = request.config.get("recognizers", DEFAULT_RECOGNIZERS)
     language = request.config.get("language", DEFAULT_LANGUAGE)
-        
+
     try:
-        # Parse and get recognizers
         recognizers = parse_recognizers(recognizer_config)
-        
-        # Create analyzer with specified recognizers
         analyzer = get_analyzer(recognizers, language)
-        
-        # Process messages
-        messages = request.requestBody.get('messages', [])
+
+        messages = body.get("messages", [])
         transformed = False
-        transformed_messages = []
-        
+        transformed_messages: list[dict[str, Any]] = []
+
         for message in messages:
             if isinstance(message, dict) and message.get("content"):
-                # Analyze for PII
                 results = analyzer.analyze(text=message["content"], language=language)
-                
-                # Anonymize detected PII
                 anonymized_content = anonymizer.anonymize(
-                    text=message["content"], 
-                    analyzer_results=results
+                    text=message["content"],
+                    analyzer_results=results,
                 )
-                
-                # Track if any transformation occurred
                 if anonymized_content.text != message["content"]:
                     transformed = True
                     logger.info(
                         f"PII detected and redacted. "
                         f"Entities found: {[r.entity_type for r in results]}"
                     )
-                
-                transformed_messages.append({
-                    "role": message["role"],
-                    "content": anonymized_content.text
-                })
-        
-        # Return transformed body only if PII was actually redacted
+                transformed_messages.append(
+                    {"role": message["role"], "content": anonymized_content.text}
+                )
+
         if transformed:
-            request.requestBody['messages'] = transformed_messages
-            return request.requestBody
+            body["messages"] = transformed_messages
         else:
-            logger.debug("No PII detected, returning None")
-            return None
-            
+            logger.debug("No PII detected")
+
+        return _response(True, transformed, body)
+
     except Exception as e:
         logger.error(f"Error during PII redaction: {str(e)}", exc_info=True)
         raise

--- a/guardrail/web_sanitization_guardrails_ai.py
+++ b/guardrail/web_sanitization_guardrails_ai.py
@@ -1,18 +1,18 @@
 from guardrails import Guard
 from guardrails_grhub_web_sanitization import WebSanitization
 
-from entities import InputGuardrailRequest
+from entities import InputGuardrailRequest, ValidateGuardrailResponse
 
 # Setup the Guard with the validator
 guard = Guard().use(WebSanitization, on_fail="exception")
 
 
-def web_sanitization(request: InputGuardrailRequest) -> dict:
+def web_sanitization(request: InputGuardrailRequest) -> ValidateGuardrailResponse:
     try:
         messages = request.requestBody.get("messages", [])
         for message in messages:
             if isinstance(message, dict) and message.get("content"):
                 guard.validate(message["content"])
     except Exception as e:
-        return {"verdict": False, "message": str(e)}
-    return {"verdict": True}
+        return ValidateGuardrailResponse(verdict=False, message=str(e))
+    return ValidateGuardrailResponse(verdict=True)

--- a/guardrail/web_sanitization_guardrails_ai.py
+++ b/guardrail/web_sanitization_guardrails_ai.py
@@ -1,5 +1,3 @@
-from typing import Optional
-from fastapi import HTTPException
 from guardrails import Guard
 from guardrails_grhub_web_sanitization import WebSanitization
 
@@ -8,12 +6,13 @@ from entities import InputGuardrailRequest
 # Setup the Guard with the validator
 guard = Guard().use(WebSanitization, on_fail="exception")
 
-def web_sanitization(request: InputGuardrailRequest) -> Optional[dict]:
+
+def web_sanitization(request: InputGuardrailRequest) -> dict:
     try:
         messages = request.requestBody.get("messages", [])
         for message in messages:
             if isinstance(message, dict) and message.get("content"):
                 guard.validate(message["content"])
-        return None
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        return {"verdict": False, "message": str(e)}
+    return {"verdict": True}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the HTTP response shape/semantics for multiple guardrail endpoints (moving from `null`/HTTP 400 to structured 2xx JSON verdicts), which can break integrations if callers expect the old behavior.
> 
> **Overview**
> Updates guardrail endpoints to return **TrueFoundry AI Gateway contract** responses: validate-style guardrails now return `ValidateGuardrailResponse` (`verdict` + optional `message`) on **HTTP 2xx** for both allow/deny instead of raising **HTTP 400** for policy blocks.
> 
> Refactors Presidio PII redaction into a mutate-style response (`MutateGuardrailResponse`) that always returns `verdict`, `transformed`, and a full `result` body (using a deep-copied request), and updates README guidance/examples to document the new 2xx/contract-based behavior and best practices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b1b49d4c8e304fef539a21a7c1a40fb9c2e3c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->